### PR TITLE
Correções

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,7 +1,6 @@
 // The module 'vscode' contains the VS Code extensibility API
 const vscode = require('vscode');
 const {
-	openGUI,
 	pullCommand, 
 	pushCommand,
 	submitCommand,
@@ -24,7 +23,6 @@ function activate(context) {
 	});
 
 	context.subscriptions.push(disposable);
-	context.subscriptions.push(openGUI);
 	context.subscriptions.push(pullCommand);
 	context.subscriptions.push(pushCommand);
 	context.subscriptions.push(submitCommand);

--- a/package.json
+++ b/package.json
@@ -21,10 +21,6 @@
         "title": "Hello World"
       },
       {
-        "command": "csmanager.openGUI",
-        "title": "CSManager"
-      },
-      {
         "command": "csmanager.pull",
         "title": "CSManager: Pull"
       },

--- a/src/scripts/push.js
+++ b/src/scripts/push.js
@@ -107,7 +107,10 @@ async function pushScripts(pScripts) {
                 .input('fileCode', sql.NVarChar, pFileCode)
                 .query(
                     `UPDATE ${mapTables.get(item.type)}
-                    SET ${pFile.split('.').slice(0, -1).join('.')} = @fileCode
+                    SET ${pFile.split('.').slice(0, -1).join('.')} = @fileCode,
+                    usrdata = CAST(GETDATE() as date), 
+                    usrhora = CONVERT(char(8), GETDATE(), 108), 
+                    usrinis = LEFT(SUSER_NAME(), 3)
                     WHERE ${mapTables.get(item.type)}stamp LIKE '%${pScriptSTAMP}%'`
                 );
 

--- a/src/scripts/scripts.js
+++ b/src/scripts/scripts.js
@@ -1,4 +1,3 @@
-const openGUI = require('./openGUI')
 const pullCommand = require('./pull')
 const pushCommand = require('./push')
 const submitCommand = require('./submit')
@@ -6,7 +5,6 @@ const checkConfiguration = require('./checkConfiguration')
 const configuration = require('./configuration')
 
 module.exports = {
-    openGUI,
     pullCommand,
     pushCommand,
     submitCommand,


### PR DESCRIPTION
Remoção da opção openGUI
Remoção da opção openGUI devido á ausencia de codigo (ficheiro scripts/openGUI.js não existe), extensão não arrancava devido á falta do mesmo


Atualização dos campos usrdata, usrhora, usrinis
Atualização dos campos é necessária para o PHC identificar que houve uma alteração código e recompilar no recarregar da página